### PR TITLE
Use views to prevent image copies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn log_2(x: u32) -> u32 {
     num_bits::<u32>() as u32 - x.leading_zeros() - 1
 }
 
-fn brightest<I, P, S>(img1: &I, img2: &I) -> ImageBuffer<P, Vec<S>>
+fn brightest<I, P, S>(img1: I, img2: I) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
@@ -43,9 +43,9 @@ fn main() {
             let left = img.view(offset, 0, win_width, win_height);
             let up = img.view(0, offset, win_width, win_height);
             let diag = img.view(offset, offset, win_width, win_height);
-            let top_pixels = brightest(&orig, &left);
-            let bottom_pixels = brightest(&up, &diag);
-            img = brightest(&top_pixels, &bottom_pixels);
+            let top_pixels = brightest(orig, left);
+            let bottom_pixels = brightest(up, diag);
+            img = brightest(top_pixels, bottom_pixels);
         }
         img.save(cli::get_out_fname(&f)).unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use image::{open, GenericImage, GenericImageView, GrayImage, Luma, Pixel};
+use image::{open, GenericImageView, GrayImage, Luma, Pixel};
 use std::cmp::min;
 
 mod cli;
@@ -12,7 +12,7 @@ fn log_2(x: u32) -> u32 {
     num_bits::<u32>() as u32 - x.leading_zeros() - 1
 }
 
-fn brightest<T: GenericImage>(img1: T, img2: T) -> GrayImage {
+fn brightest<T: GenericImageView>(img1: T, img2: T) -> GrayImage {
     GrayImage::from_fn(img1.width(), img1.height(), |x, y| {
         let p1 = img1.get_pixel(x, y);
         let p2 = img2.get_pixel(x, y);
@@ -28,7 +28,7 @@ fn brightest<T: GenericImage>(img1: T, img2: T) -> GrayImage {
 fn main() {
     let args = cli::parse_args();
     for f in args.in_file_path {
-        let mut img = open(&f).unwrap().grayscale().to_luma();
+        let mut img: image::GrayImage = open(&f).unwrap().grayscale().to_luma();
         let smaller_extent = min(img.width(), img.height());
         let rounds = log_2(smaller_extent) - 1;
         for round in 0..rounds {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use image::{open, GenericImageView, GrayImage};
+use image::{open, GenericImage, GenericImageView, GrayImage, Luma, Pixel};
 use std::cmp::min;
 
 mod cli;
@@ -12,14 +12,15 @@ fn log_2(x: u32) -> u32 {
     num_bits::<u32>() as u32 - x.leading_zeros() - 1
 }
 
-fn brightest(img1: &GrayImage, img2: &GrayImage) -> GrayImage {
+fn brightest<T: GenericImage>(img1: T, img2: T) -> GrayImage {
     GrayImage::from_fn(img1.width(), img1.height(), |x, y| {
         let p1 = img1.get_pixel(x, y);
         let p2 = img2.get_pixel(x, y);
-        if p1.0[0] < p2.0[0] {
-            *p2
+        if p1.to_luma()[0] < p2.to_luma()[0] {
+            // experimenting first with constant values before figuring out correct types
+            Luma([0u8]) //p2.to_luma()
         } else {
-            *p1
+            Luma([255u8]) //p1.to_luma()
         }
     })
 }
@@ -34,11 +35,13 @@ fn main() {
             let offset = 2u32.pow(round);
             let win_width = img.width() - offset;
             let win_height = img.height() - offset;
-            let orig = img.view(0, 0, win_width, win_height).to_image();
-            let left = img.view(offset, 0, win_width, win_height).to_image();
-            let up = img.view(0, offset, win_width, win_height).to_image();
-            let diag = img.view(offset, offset, win_width, win_height).to_image();
-            img = brightest(&brightest(&orig, &left), &brightest(&up, &diag));
+            let orig = img.view(0, 0, win_width, win_height);
+            let left = img.view(offset, 0, win_width, win_height);
+            let up = img.view(0, offset, win_width, win_height);
+            let diag = img.view(offset, offset, win_width, win_height);
+            let top_pixels = brightest(orig, left);
+            let bottom_pixels = brightest(up, diag);
+            img = brightest(top_pixels, bottom_pixels);
         }
         img.save(cli::get_out_fname(&f)).unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,9 @@ where
     ImageBuffer::from_fn(img1.width(), img1.height(), |x, y| {
         let p1 = img1.get_pixel(x, y);
         let p2 = img2.get_pixel(x, y);
-        if p1.to_luma()[0] < p2.to_luma()[0] {
-            p2
-        } else {
-            p1
+        match compare(p1.to_luma()[0], p2.to_luma()[0]) {
+            true => p1,
+            false => p2,
         }
     })
 }


### PR DESCRIPTION
I was still intrigued by the problem of using views. I ~~didn't manage~~ managed to do it, ~~but~~ and  in this ~~incomplete~~ implementation
- the `brightest()` function accepts images as `GenericImage` traits – both views and `GrayImage`s should implement that
- views are passed into `brightest()` from the main program
- ~~constant value pixels are returned since I couldn't figure out how to turn `get_pixel()` return values into `Luma`s~~

I ~~can't wrap my head around~~ solved this by using `GenericImageView` instead of `GenericImage`:
```rust
error[E0277]: the trait bound `&image::ImageBuffer<image::Luma<u8>, std::vec::Vec<u8>>: std::ops::DerefMut` is not satisfied
  --> src/main.rs:39:26
   |
14 | fn brightest<T: GenericImage>(img1: T, img2: T) -> GrayImage {
   |                 ------------ required by this bound in `brightest`
...
39 |         let top_pixels = brightest(orig, left);
   |                          ^^^^^^^^^ the trait `std::ops::DerefMut` is not implemented for `&image::ImageBuffer<image::Luma<u8>, std::vec::Vec<u8>>`
   |
   = help: the following implementations were found:
             <image::ImageBuffer<P, Container> as std::ops::DerefMut>
   = note: `std::ops::DerefMut` is implemented for `&mut image::ImageBuffer<image::Luma<u8>, std::vec::Vec<u8>>`, but not for `&image::ImageBuffer<image::Luma<u8>, std::vec::Vec<u8>>`
   = note: required because of the requirements on the impl of `image::GenericImage` for `image::SubImage<&image::ImageBuffer<image::Luma<u8>, std::vec::Vec<u8>>>`
```